### PR TITLE
TranslateValue-Operator does not translate "0"

### DIFF
--- a/lib/DataObject/GridColumnConfig/Operator/TranslateValue.php
+++ b/lib/DataObject/GridColumnConfig/Operator/TranslateValue.php
@@ -41,8 +41,8 @@ class TranslateValue extends AbstractOperator
         $childs = $this->getChilds();
         if ($childs[0]) {
             $value = $childs[0]->getLabeledValue($element);
-            if ($value->value) {
-                $value->value = $this->translator->trans($this->prefix . $value->value, []);
+            if (strval($value->value) != '') {
+                $value->value = $this->translator->trans($this->prefix . strval($value->value), []);
             }
 
             return $value;


### PR DESCRIPTION
When value to translate is String "0" the condition in line 44 will be false. So no prefix is set and no translation is executed.
